### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/s3-trigger-thumbnail/lambda-s3/index.js
+++ b/s3-trigger-thumbnail/lambda-s3/index.js
@@ -10,7 +10,7 @@ const CREDENTIALS = {
 
 let s3;
 s3 = new AWS.S3({
-    endpoint: `http://${process.env.LOCALSTACK_HOSTNAME}:${process.env.EDGE_PORT}`,
+    endpoint: process.env.AWS_ENDPOINT_URL,
     region: 'us-east-1',
     credentials: CREDENTIALS,
     s3ForcePathStyle: true


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @giograno 